### PR TITLE
fix: README install instructions — repo URL, install order, plugins.allow

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,9 @@ This plugin gives your OpenClaw agent **persistent, cross-session memory** using
 
 ## Installation
 
-```bash
-git clone https://github.com/Shubhamsaboo/openclaw-vertex-memorybank.git
-cd openclaw-vertex-memorybank
-npm install && npm run build
-openclaw plugins install .
-```
+### 1. Add plugin config to `openclaw.json`
 
-<!-- TODO: Alternative install via https://clawhub.ai/ when published -->
-
-Add to your `openclaw.json`:
+Add the config **before** installing — the plugin requires three fields to validate during install:
 
 ```json
 {
@@ -82,7 +75,39 @@ Add to your `openclaw.json`:
 }
 ```
 
-Three fields, everything else has sensible defaults. Restart OpenClaw after configuring.
+### 2. Clone, build, install
+
+```bash
+git clone https://github.com/Shubhamsaboo/openclaw-vertexai-memorybank.git
+cd openclaw-vertexai-memorybank
+npm install && npm run build
+openclaw plugins install .
+```
+
+<!-- TODO: Alternative install via https://clawhub.ai/ when published -->
+
+### 3. Trust the plugin (recommended)
+
+After install, add `plugins.allow` to your `openclaw.json` to explicitly trust the plugin and silence the "non-bundled plugin auto-load" warning:
+
+```json
+{
+  "plugins": {
+    "allow": ["openclaw-vertex-memorybank"],
+    "entries": { ... }
+  }
+}
+```
+
+> **Why not add `allow` in step 1?** OpenClaw validates that allowed plugins are actually installed — adding it before install causes a validation error.
+
+### 4. Restart
+
+```bash
+openclaw restart
+```
+
+The plugin loads on gateway startup — a restart is required after install.
 
 ### Bootstrapping from existing sessions
 


### PR DESCRIPTION
## Fixes

Three friction points discovered during end-to-end onboarding on a clean OpenClaw sandbox:

### 1. Wrong clone URL (HIGH)
README had `openclaw-vertex-memorybank` but the repo is now `openclaw-vertexai-memorybank`. First step broken for anyone following the docs.

### 2. Install order chicken-and-egg (HIGH)
`openclaw plugins install .` validates the plugin config schema on install. If `projectId`, `location`, `reasoningEngineId` aren't in `openclaw.json` yet, the install crashes:
```
Config validation failed: plugins.entries.openclaw-vertex-memorybank.config.projectId: must have required property 'projectId'
```
**Fix:** Reordered to config-first, then install.

### 3. `plugins.allow` timing (MEDIUM)
If `plugins.allow: ["openclaw-vertex-memorybank"]` is set before the plugin is installed, OpenClaw rejects the config:
```
plugins.allow: plugin not found: openclaw-vertex-memorybank
```
**Fix:** Moved `plugins.allow` to a separate step after install, with a note explaining why.

## Testing
Full end-to-end on a clean sandbox:
1. Fresh `openclaw.json` with no plugin references
2. Add config (step 1) → install (step 2) → add `plugins.allow` (step 3) → restart (step 4)
3. All CLI commands verified: `memorybank-status`, `memorybank-remember`, `memorybank-search`, `memorybank-list --count-only`
4. No warnings with `plugins.allow` set