### PR TITLE
fix: add topic labels to few-shot generated memories

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -107,7 +107,7 @@ const DEFAULT_FEW_SHOTS = [
       ],
     },
     generatedMemories: [
-      { fact: "The user does not want memories to expire. TTL should not be enabled by default." },
+      { fact: "The user does not want memories to expire. TTL should not be enabled by default.", topics: [{ managed_memory_topic: "USER_PREFERENCES" }] },
     ],
   },
   // Positive: user preference
@@ -119,7 +119,7 @@ const DEFAULT_FEW_SHOTS = [
       ],
     },
     generatedMemories: [
-      { fact: "The user prefers not to bump versions for incremental changes." },
+      { fact: "The user prefers not to bump versions for incremental changes.", topics: [{ managed_memory_topic: "USER_PREFERENCES" }] },
     ],
   },
 ];


### PR DESCRIPTION
Add managed_memory_topic labels to the positive few-shot examples so the model learns the association between facts and topics.

Closes #2Add `managed_memory_topic` labels to the positive few-shot examples so the model learns the association between facts and topics.

Closes #2